### PR TITLE
#7 hotfix implementation

### DIFF
--- a/src/HTTP/APIRequest.php
+++ b/src/HTTP/APIRequest.php
@@ -255,7 +255,7 @@ class APIRequest {
             
             $delay = (int) $this->api->client->getOption('http.requestErrorDelay', 30);
             if ($this->retries > 2) {
-                $delay *= 2;
+                //$delay *= 2; /* https://github.com/valzargaming/Yasmin/issues/7# */
             }
             
             $this->api->client->addTimer($delay, function() use (&$ratelimit) {
@@ -269,13 +269,12 @@ class APIRequest {
             return null;
         } elseif ($status === 429) {
             $this->api->client->emit('debug', 'Unshifting item "'.$this->endpoint.'" due to HTTP 429');
-            
+			$this->api->slowDown(); /* https://github.com/valzargaming/Yasmin/issues/7# */			
             if ($ratelimit !== null) {
                 $this->api->unshiftQueue($ratelimit->unshift($this));
             } else {
                 $this->api->unshiftQueue($this);
             }
-            
             return null;
         }
         

--- a/src/HTTP/APIRequest.php
+++ b/src/HTTP/APIRequest.php
@@ -255,7 +255,7 @@ class APIRequest {
             
             $delay = (int) $this->api->client->getOption('http.requestErrorDelay', 30);
             if ($this->retries > 2) {
-                //$delay *= 2; /* https://github.com/valzargaming/Yasmin/issues/7# */
+                $delay *= 2;
             }
             
             $this->api->client->addTimer($delay, function() use (&$ratelimit) {


### PR DESCRIPTION
This should prevent those nasty 429s. Requests should not be made to any bucket more than once every half second. If a 429 still manages to get hit then the delay gets doubled, although I haven't actually had this happen yet.
